### PR TITLE
Add parameters for export webhook completion headers

### DIFF
--- a/plagiarism-checker.gemspec
+++ b/plagiarism-checker.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/Copyleaks/Ruby-Plagiarism-Checker/releases'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:demo|test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:demo|test|spec|features)/}) || f.match(/\.gem/) }
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{\Abin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 end


### PR DESCRIPTION
Adds `completionWebhookHeaders` parameter to `Copyleaks::CopyleaksExportModel` class per https://api.copyleaks.com/documentation/v3/downloads/export