### PR TITLE
Add parameter for aiGeneratedText submission properties

### DIFF
--- a/lib/copyleaks/models/submissions/properties/ai_generated_text.rb
+++ b/lib/copyleaks/models/submissions/properties/ai_generated_text.rb
@@ -1,7 +1,7 @@
 #
 #  The MIT License(MIT)
 #
-#  Copyright(c) 2016 Copyleaks LTD (https://copyleaks.com)
+#  Copyright(c) 2023 Copyleaks LTD (https://copyleaks.com)
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -21,26 +21,23 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 # =
-
-require_relative 'submission_properties.rb'
-
-require_relative 'actions.rb'
-require_relative 'ai_generated_text.rb'
-require_relative 'author.rb'
-require_relative 'copyleaks_db.rb'
-require_relative 'domains_mode.rb'
-require_relative 'exclude.rb'
-require_relative 'filter.rb'
-require_relative 'scan_method_algorithm.rb'
-require_relative 'indexing.rb'
-require_relative 'pdf_properties.rb'
-require_relative 'repository.rb'
-require_relative 'scanning.rb'
-require_relative 'scanning_exclude.rb'
-require_relative 'scanning_repository.rb'
-require_relative 'sensitive_data_protection.rb'
-require_relative 'submission_properties.rb'
-require_relative 'webhooks.rb'
-
 module Copyleaks
+  class SubmissionAiGeneratedText
+    # @param [Boolean] detect Detects whether the text was written by an AI.
+    def initialize(
+      detect = false
+    )
+      @detect = detect
+    end
+
+    def as_json(*_args)
+      {
+        detect: @detect
+      }.select { |_k, v| !v.nil? }
+    end
+
+    def to_json(*options)
+      as_json(*options).to_json(*options)
+    end
+  end
 end

--- a/lib/copyleaks/models/submissions/properties/submission_properties.rb
+++ b/lib/copyleaks/models/submissions/properties/submission_properties.rb
@@ -45,7 +45,8 @@ module Copyleaks
     def initialize(
       webhooks, includeHtml = nil, developerPayload = nil, sandbox = nil, expiration = nil,
       sensitivityLevel = nil, cheatDetection = nil, action = nil, author = nil, filters = nil,
-      scanning = nil, indexing = nil, exclude = nil, pdf = nil, sensitiveDataProtection = nil, scanMethodAlgorithm = nil
+      scanning = nil, indexing = nil, exclude = nil, pdf = nil, sensitiveDataProtection = nil,
+      scanMethodAlgorithm = nil, aiGeneratedText = nil
     )
       unless webhooks.instance_of?(SubmissionWebhooks)
         raise 'Copyleaks::SubmissionProperties - webhooks - webhooks must be of type SubmissionWebhooks'
@@ -93,7 +94,10 @@ module Copyleaks
         raise 'Copyleaks::SubmissionProperties - sensitiveDataProtection - sensitiveDataProtection must be of type SubmissionSensitiveData'
       end
       if !scanMethodAlgorithm.nil? && ![0, 1].include?(scanMethodAlgorithm)
-        raise 'Copyleaks::SubmissionProperties - scanMethodAlgorithm - action must be of type SubmissionScanMethodAlgorithm consts'
+        raise 'Copyleaks::SubmissionProperties - scanMethodAlgorithm - scanMethodAlgorithm must be of type SubmissionScanMethodAlgorithm'
+      end
+      if !aiGeneratedText.nil? && !aiGeneratedText.instance_of?(SubmissionAiGeneratedText)
+        raise 'Copyleaks::SubmissionProperties - aiGeneratedText - aiGeneratedText must be of type SubmissionAiGeneratedText'
       end
 
       @webhooks = webhooks
@@ -103,6 +107,7 @@ module Copyleaks
       @expiration = expiration
       @sensitivityLevel = sensitivityLevel
       @cheatDetection = cheatDetection
+      @aiGeneratedText = aiGeneratedText
       @action = action
       @author = author
       @filters = filters
@@ -123,6 +128,7 @@ module Copyleaks
         expiration: @expiration,
         sensitivityLevel: @sensitivityLevel,
         cheatDetection: @cheatDetection,
+        aiGeneratedText: @aiGeneratedText,
         action: @action,
         author: @author,
         filters: @filters,


### PR DESCRIPTION
Adds support for `properties.aiGeneratedText.detect` for the [scans submit](https://api.copyleaks.com/documentation/v3/scans/submit/file) API.