### PR TITLE
File Dependency Fix

### DIFF
--- a/lib/copyleaks/models/submissions/properties/indexing_repository.rb
+++ b/lib/copyleaks/models/submissions/properties/indexing_repository.rb
@@ -21,6 +21,9 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 # =
+
+require_relative  './repository.rb'
+
 module Copyleaks
     class SubmissionIndexingRepository < SubmissionRepository
       # @param [String] ID of a repository to add the scanned document to.


### PR DESCRIPTION
Fixed file dependency where `SubmissionIndexingRepository` is dependent on `SubmissionRepository` but `SubmissionRepository` was loading after `SubmissionIndexingRepository` causing an error when performing `require 'copyleaks'` in `irb` or when running `bin/console`.