### PR TITLE
Refactor to raise Copyleaks exceptions

### DIFF
--- a/lib/copyleaks/models/exceptions/auth_expired_exception.rb
+++ b/lib/copyleaks/models/exceptions/auth_expired_exception.rb
@@ -22,11 +22,9 @@
 #  SOFTWARE.
 # =
 module Copyleaks
-  class AuthExipredException < StandardError
-    attr_reader :reason
-
+  class AuthExpiredException < RuntimeError
     def initialize
-      @reason = 'Authentication Expired. Need to login again'
+      super 'Authentication Expired. Need to login again'
     end
   end
 end

--- a/lib/copyleaks/models/exceptions/command_exception.rb
+++ b/lib/copyleaks/models/exceptions/command_exception.rb
@@ -22,11 +22,18 @@
 #  SOFTWARE.
 # =
 module Copyleaks
-  class CommandException < StandardError
-    attr_reader :reason
+  class CommandException < RuntimeError
+    attr_reader :response
 
-    def initialize(reason)
-      @reason = reason
+    def initialize(response:, used_by:)
+      @response = response
+      @used_by = used_by
+
+      message = "---------Copyleaks SDK Error (#{used_by})---------\n\n"
+      message += "status code: #{response.code}\n\n"
+      message += "response body:\n#{response.body.to_json}\n\n" unless response.body.nil?
+      message += "-------------------------------------\n"
+      super message
     end
   end
 end

--- a/lib/copyleaks/models/exceptions/index.rb
+++ b/lib/copyleaks/models/exceptions/index.rb
@@ -22,7 +22,7 @@
 #  SOFTWARE.
 # =
 
-require_relative 'auth_exipred_exception.rb'
+require_relative 'auth_expired_exception.rb'
 require_relative 'command_exception.rb'
 require_relative 'rate_limit_exception.rb'
 require_relative 'under_maintenance_exception.rb'

--- a/lib/copyleaks/models/exceptions/rate_limit_exception.rb
+++ b/lib/copyleaks/models/exceptions/rate_limit_exception.rb
@@ -22,11 +22,9 @@
 #  SOFTWARE.
 # =
 module Copyleaks
-  class RateLimitException < StandardError
-    attr_reader :reason
-
+  class RateLimitException < RuntimeError
     def initialize
-      @reason = 'Too many requests. Please wait before calling again.'
+      super 'Too many requests. Please wait before calling again.'
     end
   end
 end

--- a/lib/copyleaks/models/exceptions/under_maintenance_exception.rb
+++ b/lib/copyleaks/models/exceptions/under_maintenance_exception.rb
@@ -22,11 +22,9 @@
 #  SOFTWARE.
 # =
 module Copyleaks
-  class UnderMaintenanceException < StandardError
-    attr_reader :reason
-
+  class UnderMaintenanceException < RuntimeError
     def initialize
-      @reason = 'Copyleaks is Under Maintenance, please visit https://status.copyleaks.com'
+      super 'Copyleaks is Under Maintenance, please visit https://status.copyleaks.com'
     end
   end
 end

--- a/lib/copyleaks/utils/copyleaks_client.utils.rb
+++ b/lib/copyleaks/utils/copyleaks_client.utils.rb
@@ -29,22 +29,14 @@ module Copyleaks
         if response.body.nil? || response.body == ''
           nil
         else
-          parsed_response = JSON.parse(response.body)
-          puts "Parsed response: #{parsed_response.inspect}"
-          parsed_response
+          JSON.parse(response.body)
         end
       elsif Utils.is_under_maintenance_response(response.code)
-        raise UnderMaintenanceException.new.reason
+        raise UnderMaintenanceException
       elsif Utils.is_rate_limit_response(response.code)
-        raise RateLimitException.new.reason
+        raise RateLimitException
       else
-        _err_message = '---------Copyleaks SDK Error (' + used_by + ')---------' + "\n\n"
-        _err_message += 'status code: ' + response.code + "\n\n"
-
-        _err_message += 'response body:' + "\n" + response.body.to_json + "\n\n" unless response.body.nil?
-
-        _err_message += '-------------------------------------'
-        raise CommandException.new(_err_message).reason + "\n"
+        raise CommandException.new(response: response, used_by: used_by)
       end
     end
 
@@ -57,7 +49,7 @@ module Copyleaks
       _expiresTime = DateTime.parse(authToken.expires)
 
       if _expiresTime <= _time
-        raise AuthExipredException.new.reason # expired
+        raise AuthExpiredException # expired
       end
     end
   end


### PR DESCRIPTION
All of these exceptions are currently raised as RuntimeErrors with messages pulled from the library's exceptions. This change simplifies error handling. To maintain backward compatibility, the exceptions now inherit from RuntimeError.

### Before
```ruby
> raise Copyleaks::RateLimitException.new.reason
RuntimeError: Too many requests. Please wait before calling again.
```

### After
```ruby
> raise Copyleaks::RateLimitException
Copyleaks::RateLimitException: Too many requests. Please wait before calling again.
```