### PR TITLE
added deprecation warning message

### DIFF
--- a/lib/copyleaks.rb
+++ b/lib/copyleaks.rb
@@ -21,7 +21,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 # =
-
+warn "\e[33m[DEPRECATION] plagiarism-checker: AI Code Detection will be discontinued on August 29, 2025. See README for more info.\e[0m"
 require_relative  './copyleaks/api.rb'
 require_relative  './copyleaks/version.rb'
 require_relative  './copyleaks/app.config.rb'

--- a/plagiarism-checker.gemspec
+++ b/plagiarism-checker.gemspec
@@ -19,7 +19,17 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/Copyleaks/Ruby-Plagiarism-Checker'
   spec.metadata['changelog_uri'] = 'https://github.com/Copyleaks/Ruby-Plagiarism-Checker/releases'
+spec.post_install_message = <<-MSG
 
+\e[33m===============================================================
+DEPRECATION NOTICE: plagiarism-checker v#{Copyleaks::VERSION}
+===============================================================
+AI Code Detection will be discontinued on August 29, 2025.
+Please remove AI code detection integrations before the sunset date.
+===============================================================\e[0m
+
+MSG
+  
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:demo|test|spec|features)/}) || f.match(/\.gem/) }
   end


### PR DESCRIPTION
added deprecation warning for AI Code detection.
"AI Code Detection will be discontinued on August 29, 2025. Please remove AI code detection integrations before the sunset date." when updating the package version or installing the package.